### PR TITLE
Add  `ec2:DescribeSecurityGroups`

### DIFF
--- a/policy.json
+++ b/policy.json
@@ -11,6 +11,7 @@
         "ec2:DeleteKeypair",
         "ec2:CreateSecurityGroup",
         "ec2:DeleteSecurityGroup",
+        "ec2:DescribeSecurityGroups",
         "ec2:AuthorizeSecurityGroupIngress",
         "ec2:CreateImage",
         "ec2:RunInstances",


### PR DESCRIPTION
because its necessary in packer current version.
ref: https://github.com/hashicorp/packer/blob/7a189a83a19c1acabbcdb505120653e0aa77ea46/builder/alicloud/ecs/step_config_security_group.go#L39